### PR TITLE
feat: input cards & padding/coloring fixes

### DIFF
--- a/frontend/app/(app)/borrow/[marketId]/page.tsx
+++ b/frontend/app/(app)/borrow/[marketId]/page.tsx
@@ -300,7 +300,7 @@ export default function MarketPage() {
               Disclosures <InfoIcon className="h-4 w-4 text-gray-400" />
             </h2>
             <Card className={CARD_STYLES}>
-              <CardContent className="pt-6">
+              <CardContent className="">
                 <p className="text-gray-400">Curator has not submitted a Disclosure.</p>
               </CardContent>
             </Card>

--- a/frontend/app/(app)/borrow/[marketId]/page.tsx
+++ b/frontend/app/(app)/borrow/[marketId]/page.tsx
@@ -1,15 +1,17 @@
 "use client"
 
 import "@/app/theme.css"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
 import { InfoIcon } from "lucide-react"
 import { useParams } from "next/navigation"
 import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
 import { formatUnits } from "viem"
 import { MarketChart } from "../components/market-chart"
 import { assets } from "../mock"
 import { marketHistory } from "../mock-history"
-
 export default function MarketPage() {
   const params = useParams()
   const decodedMarketId = decodeURIComponent(params.marketId as string)
@@ -21,6 +23,40 @@ export default function MarketPage() {
     sevenDay: 0,
     ninetyDay: 0
   })
+
+  // Form handling with React Hook Form
+  const { register, handleSubmit, setValue, watch } = useForm({
+    defaultValues: {
+      supplyAmount: "",
+      borrowAmount: ""
+    }
+  })
+
+  const supplyAmount = watch("supplyAmount")
+  const borrowAmount = watch("borrowAmount")
+
+  // Calculate supply value in USD
+  const supplyValue = supplyAmount ? 
+    parseFloat(supplyAmount) * Number(formatUnits(BigInt(market?.price || "0"), 18)) : 0
+
+  // Calculate borrow value in USD
+  const borrowValue = borrowAmount ? 
+    parseFloat(borrowAmount) : 0
+
+  const onSubmit = (data: unknown) => {
+    console.log("Form submitted:", data)
+    // This would handle the borrow/supply action
+  }
+
+  const handleMaxSupply = () => {
+    // For demonstration, set a mock max value
+    setValue("supplyAmount", "1000.00")
+  }
+
+  const handleMaxBorrow = () => {
+    // For demonstration, set a mock max value based on collateral
+    setValue("borrowAmount", "500.00")
+  }
 
   // Calculate random variations once after mount
   useEffect(() => {
@@ -35,240 +71,345 @@ export default function MarketPage() {
   }
 
   return (
-    <div className="items-center justify-center space-y-6 -mt-6">
+    <div className="items-center justify-center space-y-6 -mt-6 py-6">
       <h1 className="text-[36px] font-bold mb-6 text-gray-200">
         {market.loanSymbol} / {market.collateralSymbol} Market
       </h1>
       
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-4">
-      <Card className="bg-gray-700/60 border-none">
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 relative">
+        {/* Left side - market information */}
+        <div className="col-span-1 lg:col-span-3 space-y-6">
+          {/* Market info cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-4">
+            {/* Market Overview Card */}
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader>
+                <CardTitle className="text-gray-200">Market Overview</CardTitle>
+                <CardDescription className="text-gray-400">Basic information about the market</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-2">
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Loan Token</span>
+                  <span className="font-medium text-gray-200">{market.loanSymbol}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Collateral Token</span>
+                  <span className="font-medium text-gray-200">{market.collateralSymbol}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Price</span>
+                  <span className="font-medium text-gray-200">
+                    {Number(formatUnits(BigInt(market.price), 18)).toFixed(2)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
 
-      <CardHeader>
-            <CardTitle className="text-gray-200">Market Overview</CardTitle>
-            <CardDescription className="text-gray-400">Basic information about the market</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-2">
-            <div className="flex justify-between">
-              <span className="text-gray-400">Loan Token</span>
-              <span className="font-medium text-gray-200">{market.loanSymbol}</span>
+            {/* Market Size Card */}
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader>
+                <CardTitle className="text-gray-200">Market Size</CardTitle>
+                <CardDescription className="text-gray-400">Supply and borrow information</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-2">
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Total Supply</span>
+                  <span className="font-medium text-gray-200">
+                    {Number(formatUnits(BigInt(market.totalSupplyAssets), 18)).toFixed(2)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Total Borrow</span>
+                  <span className="font-medium text-gray-200">
+                    {Number(formatUnits(BigInt(market.totalBorrowAssets), 18)).toFixed(2)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Utilization</span>
+                  <span className="font-medium text-gray-200">
+                    {(Number(formatUnits(BigInt(market.totalBorrowAssets), 18)) / 
+                      Number(formatUnits(BigInt(market.totalSupplyAssets), 18)) * 100).toFixed(2)}%
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Parameters Card */}
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader>
+                <CardTitle className="text-gray-200">Parameters</CardTitle>
+                <CardDescription className="text-gray-400">Market parameters and rates</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-2">
+                <div className="flex justify-between">
+                  <span className="text-gray-400">APY</span>
+                  <span className="font-medium text-gray-200">{market.apy}%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Max LTV</span>
+                  <span className="font-medium text-gray-200">
+                    {(Number(formatUnits(BigInt(market.lltv), 18)) * 100).toFixed(0)}%
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Fee</span>
+                  <span className="font-medium text-gray-200">
+                    {(Number(formatUnits(BigInt(market.fee), 18))).toFixed(2)}%
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Charts */}
+          <div className="grid grid-cols-1 gap-6">
+            <MarketChart
+              data={history}
+              title="Total Supply"
+              description="Total assets supplied to the market"
+              dataKey="supply"
+              color="rgba(34, 197, 94, 0.95)"
+            />
+            <MarketChart
+              data={history}
+              title="Total Borrow"
+              description="Total assets borrowed from the market"
+              dataKey="borrow"
+              color="rgba(239, 68, 68, 0.95)"
+            />
+            <MarketChart
+              data={history}
+              title="Utilization Rate"
+              description="Percentage of supplied assets being borrowed"
+              dataKey="utilization"
+              color="rgba(99, 102, 241, 0.95)"
+            />
+            <MarketChart
+              data={history}
+              title="APY"
+              description="Annual Percentage Yield"
+              dataKey="apy"
+              color="rgba(245, 158, 11, 0.95)"
+            />
+          </div>
+
+          {/* Performance Section */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader>
+                <CardTitle className="text-gray-200">7D APY</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold text-gray-200">
+                  {(market.apy * apyVariations.sevenDay).toFixed(2)}%
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader>
+                <CardTitle className="text-gray-200">30D APY</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold text-gray-200">
+                  {market.apy.toFixed(2)}%
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader>
+                <CardTitle className="text-gray-200">90D APY</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold text-gray-200">
+                  {(market.apy * apyVariations.ninetyDay).toFixed(2)}%
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Risk Section */}
+          <div className="space-y-6">
+            <h2 className="text-xl font-bold text-gray-200">Risk</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Card className="bg-gray-700/60 border-none rounded-3xl">
+                <CardHeader>
+                  <CardTitle className="text-gray-200 flex items-center gap-2">
+                    Risk Rating by Credora ®
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-gray-400">Has not been rated yet</div>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-gray-700/60 border-none rounded-3xl">
+                <CardHeader>
+                  <CardTitle className="text-gray-200">Curator TVL</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-gray-200 text-2xl font-bold">$578.40M</div>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-gray-700/60 border-none rounded-3xl">
+                <CardHeader>
+                  <CardTitle className="text-gray-200">Vault Deployment Date</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-gray-200">15/03/2024</div>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-gray-700/60 border-none rounded-3xl">
+                <CardHeader>
+                  <CardTitle className="text-gray-200">Owner</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-gray-200 font-mono">0x3300...f8c4</div>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-gray-700/60 border-none rounded-3xl">
+                <CardHeader>
+                  <CardTitle className="text-gray-200">Curator Address</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-gray-200 font-mono">0x0000...0000</div>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-gray-700/60 border-none rounded-3xl">
+                <CardHeader>
+                  <CardTitle className="text-gray-200">Timelock / Guardian</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-gray-200">1D / 0x0000...0000</div>
+                </CardContent>
+              </Card>
             </div>
-            <div className="flex justify-between">
-              <span className="text-gray-400">Collateral Token</span>
-              <span className="font-medium text-gray-200">{market.collateralSymbol}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-400">Price</span>
-              <span className="font-medium text-gray-200">
-                {Number(formatUnits(BigInt(market.price), 18)).toFixed(2)}
-              </span>
-            </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card className="bg-gray-700/60 border-none">
-
-        <CardHeader>
-            <CardTitle className="text-gray-200">Market Size</CardTitle>
-            <CardDescription className="text-gray-400">Supply and borrow information</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-2">
-            <div className="flex justify-between">
-              <span className="text-gray-400">Total Supply</span>
-              <span className="font-medium text-gray-200">
-                {Number(formatUnits(BigInt(market.totalSupplyAssets), 18)).toFixed(2)}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-400">Total Borrow</span>
-              <span className="font-medium text-gray-200">
-                {Number(formatUnits(BigInt(market.totalBorrowAssets), 18)).toFixed(2)}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-400">Utilization</span>
-              <span className="font-medium text-gray-200">
-                {(Number(formatUnits(BigInt(market.totalBorrowAssets), 18)) / 
-                  Number(formatUnits(BigInt(market.totalSupplyAssets), 18)) * 100).toFixed(2)}%
-              </span>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="bg-gray-700/60 border-none">
-
-        <CardHeader>
-            <CardTitle className="text-gray-200">Parameters</CardTitle>
-            <CardDescription className="text-gray-400">Market parameters and rates</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-2">
-            <div className="flex justify-between">
-              <span className="text-gray-400">APY</span>
-              <span className="font-medium text-gray-200">{market.apy}%</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-400">Max LTV</span>
-              <span className="font-medium text-gray-200">
-                {(Number(formatUnits(BigInt(market.lltv), 18)) * 100).toFixed(0)}%
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-400">Fee</span>
-              <span className="font-medium text-gray-200">
-                {(Number(formatUnits(BigInt(market.fee), 18))).toFixed(2)}%
-              </span>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="grid grid-cols-1 gap-6">
-        <MarketChart
-          data={history}
-          title="Total Supply"
-          description="Total assets supplied to the market"
-          dataKey="supply"
-          color="rgba(34, 197, 94, 0.95)"
-        />
-        <MarketChart
-          data={history}
-          title="Total Borrow"
-          description="Total assets borrowed from the market"
-          dataKey="borrow"
-          color="rgba(239, 68, 68, 0.95)"
-        />
-        <MarketChart
-          data={history}
-          title="Utilization Rate"
-          description="Percentage of supplied assets being borrowed"
-          dataKey="utilization"
-          color="rgba(99, 102, 241, 0.95)"
-        />
-        <MarketChart
-          data={history}
-          title="APY"
-          description="Annual Percentage Yield"
-          dataKey="apy"
-          color="rgba(245, 158, 11, 0.95)"
-        />
-      </div>
-
-      {/* Performance Section */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-      <Card className="bg-gray-700/60 border-none">
-
-      <CardHeader>
-            <CardTitle className="text-gray-200">7D APY</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-gray-200">
-              {(market.apy * apyVariations.sevenDay).toFixed(2)}%
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="bg-gray-700/60 border-none">
-
-        <CardHeader>
-            <CardTitle className="text-gray-200">30D APY</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-gray-200">
-              {market.apy.toFixed(2)}%
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="bg-gray-700/60 border-none">
-
-        <CardHeader>
-            <CardTitle className="text-gray-200">90D APY</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-gray-200">
-              {(market.apy * apyVariations.ninetyDay).toFixed(2)}%
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="space-y-6">
-        <h2 className="text-xl font-bold text-gray-200">Risk</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <Card className="bg-gray-700/60 border-none">
-
-        <CardHeader>
-              <CardTitle className="text-gray-200 flex items-center gap-2">
-                Risk Rating by Credora ®
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-gray-400">Has not been rated yet</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gray-700/60 border-none">
-
-          <CardHeader>
-              <CardTitle className="text-gray-200">Curator TVL</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-gray-200 text-2xl font-bold">$578.40M</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gray-700/60 border-none">
-
-          <CardHeader>
-              <CardTitle className="text-gray-200">Vault Deployment Date</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-gray-200">15/03/2024</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gray-700/60 border-none">
-
-          <CardHeader>
-              <CardTitle className="text-gray-200">Owner</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-gray-200 font-mono">0x3300...f8c4</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gray-700/60 border-none">
-
-          <CardHeader>
-              <CardTitle className="text-gray-200">Curator Address</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-gray-200 font-mono">0x0000...0000</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gray-700/60 border-none">
-
-          <CardHeader>
-              <CardTitle className="text-gray-200">Timelock / Guardian</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-gray-200">1D / 0x0000...0000</div>
-            </CardContent>
-          </Card>
+          {/* Disclosures Section */}
+          <div className="space-y-6">
+            <h2 className="text-xl font-bold text-gray-200 flex items-center gap-2">
+              Disclosures <InfoIcon className="h-4 w-4 text-gray-400" />
+            </h2>
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardContent className="pt-6">
+                <p className="text-gray-400">Curator has not submitted a Disclosure.</p>
+              </CardContent>
+            </Card>
+          </div>
         </div>
-      </div>
 
-      {/* Disclosures Section */}
-      <div className="space-y-6">
-        <h2 className="text-xl font-bold text-gray-200 flex items-center gap-2">
-          Disclosures <InfoIcon className="h-4 w-4 text-gray-400" />
-        </h2>
-        <Card className="bg-gray-700/60 border-none">
+        {/* Right side - input cards */}
+        <div className="col-span-1 lg:sticky top-6 self-start max-h-[calc(100vh-4rem)] overflow-y-auto">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            {/* Supply Card */}
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-gray-200 text-base font-medium">
+                  Supply Collateral {market.collateralSymbol}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Input
+                  type="text"
+                  {...register("supplyAmount", { 
+                    pattern: /^[0-9]*\.?[0-9]*$/
+                  })}
+                  className="text-4xl font-semibold text-gray-200 bg-transparent w-full border-none focus:outline-none p-0"
+                  placeholder="0.00"
+                />
+                <div className="flex justify-between items-center">
+                  <span className="text-sm text-gray-400">${supplyValue.toFixed(2)}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400">0.00 {market.collateralSymbol}</span>
+                    <button 
+                      type="button" 
+                      className="text-xs text-blue-500 font-medium"
+                      onClick={handleMaxSupply}
+                    >
+                      MAX
+                    </button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
 
-        <CardContent className="pt-6">
-            <p className="text-gray-400">Curator has not submitted a Disclosure.</p>
-          </CardContent>
-        </Card>
+            {/* Borrow Card */}
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-gray-200 text-base font-medium">
+                  Borrow {market.loanSymbol}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Input
+                  type="text"
+                  {...register("borrowAmount", { 
+                    pattern: /^[0-9]*\.?[0-9]*$/
+                  })}
+                  className="text-4xl font-semibold text-gray-200 bg-transparent w-full border-none focus:outline-none p-0"
+                  placeholder="0.00"
+                />
+                <div className="flex justify-between items-center">
+                  <span className="text-sm text-gray-400">${borrowValue.toFixed(2)}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400">0.00 {market.loanSymbol}</span>
+                    <button 
+                      type="button" 
+                      className="text-xs text-blue-500 font-medium"
+                      onClick={handleMaxBorrow}
+                    >
+                      MAX
+                    </button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Position Card */}
+            <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <CardContent className="pt-4 space-y-4">
+                <div>
+                  <div className="text-sm text-gray-400">My collateral position ({market.collateralSymbol})</div>
+                  <div className="text-xl font-semibold text-gray-200">0.00</div>
+                </div>
+                
+                <div>
+                  <div className="text-sm text-gray-400">My loan position ({market.loanSymbol})</div>
+                  <div className="text-xl font-semibold text-gray-200">0.00</div>
+                </div>
+                
+                <div>
+                  <div className="text-sm text-gray-400">LTV / Liquidation LTV</div>
+                  <div className="text-xl font-semibold text-gray-200">
+                    0% / {(Number(formatUnits(BigInt(market.lltv), 18)) * 100).toFixed(0)}%
+                  </div>
+                  
+                  <div className="mt-2 relative">
+                    <div className="h-2 bg-gray-600 rounded-full w-full"></div>
+                    <div className="absolute left-0 top-0 w-1/2 h-full opacity-0">
+                      <div className="absolute left-0 -top-1 h-4 w-4 bg-white rounded-full"></div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Submit Button */}
+            <Button
+              type="submit" 
+              className="w-full bg-gray-700/60 text-gray-300 rounded-2xl hover:bg-gray-600/60 transition-colors text-lg"
+              disabled={!supplyAmount && !borrowAmount}
+            >
+              {!supplyAmount && !borrowAmount ? "Enter an amount" : "Submit Transaction"}
+            </Button>
+          </form>
+        </div>
       </div>
     </div>
   )

--- a/frontend/app/(app)/borrow/[marketId]/page.tsx
+++ b/frontend/app/(app)/borrow/[marketId]/page.tsx
@@ -12,19 +12,20 @@ import { formatUnits } from "viem"
 import { MarketChart } from "../components/market-chart"
 import { assets } from "../mock"
 import { marketHistory } from "../mock-history"
+
+const CARD_STYLES = "bg-gray-700/60 border-none rounded-3xl"
+
 export default function MarketPage() {
   const params = useParams()
   const decodedMarketId = decodeURIComponent(params.marketId as string)
   const market = assets.find((asset) => asset.id === decodedMarketId)
   const history = marketHistory[decodedMarketId]
 
-  // Add state for APY variations
   const [apyVariations, setApyVariations] = useState({
     sevenDay: 0,
     ninetyDay: 0
   })
 
-  // Form handling with React Hook Form
   const { register, handleSubmit, setValue, watch } = useForm({
     defaultValues: {
       supplyAmount: "",
@@ -35,31 +36,29 @@ export default function MarketPage() {
   const supplyAmount = watch("supplyAmount")
   const borrowAmount = watch("borrowAmount")
 
-  // Calculate supply value in USD
   const supplyValue = supplyAmount ? 
     parseFloat(supplyAmount) * Number(formatUnits(BigInt(market?.price || "0"), 18)) : 0
 
-  // Calculate borrow value in USD
   const borrowValue = borrowAmount ? 
     parseFloat(borrowAmount) : 0
 
   const onSubmit = (data: unknown) => {
     console.log("Form submitted:", data)
-    // This would handle the borrow/supply action
+    // todo: send tx to the contract
   }
 
   const handleMaxSupply = () => {
-    // For demonstration, set a mock max value
+    // todo: set true maximum value according to the user's balance (maybe use tokenhub)
     setValue("supplyAmount", "1000.00")
   }
 
   const handleMaxBorrow = () => {
-    // For demonstration, set a mock max value based on collateral
+    // todo: set true maximum value according to the user's balance
     setValue("borrowAmount", "500.00")
   }
 
-  // Calculate random variations once after mount
   useEffect(() => {
+    // todo: get real apy variations from the contract
     setApyVariations({
       sevenDay: 1 + Math.random() * 0.1,
       ninetyDay: 1 - Math.random() * 0.1
@@ -82,7 +81,7 @@ export default function MarketPage() {
           {/* Market info cards */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-4">
             {/* Market Overview Card */}
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader>
                 <CardTitle className="text-gray-200">Market Overview</CardTitle>
                 <CardDescription className="text-gray-400">Basic information about the market</CardDescription>
@@ -106,7 +105,7 @@ export default function MarketPage() {
             </Card>
 
             {/* Market Size Card */}
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader>
                 <CardTitle className="text-gray-200">Market Size</CardTitle>
                 <CardDescription className="text-gray-400">Supply and borrow information</CardDescription>
@@ -135,7 +134,7 @@ export default function MarketPage() {
             </Card>
 
             {/* Parameters Card */}
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader>
                 <CardTitle className="text-gray-200">Parameters</CardTitle>
                 <CardDescription className="text-gray-400">Market parameters and rates</CardDescription>
@@ -169,6 +168,7 @@ export default function MarketPage() {
               description="Total assets supplied to the market"
               dataKey="supply"
               color="rgba(34, 197, 94, 0.95)"
+              className={CARD_STYLES}
             />
             <MarketChart
               data={history}
@@ -176,6 +176,7 @@ export default function MarketPage() {
               description="Total assets borrowed from the market"
               dataKey="borrow"
               color="rgba(239, 68, 68, 0.95)"
+              className={CARD_STYLES}
             />
             <MarketChart
               data={history}
@@ -183,6 +184,7 @@ export default function MarketPage() {
               description="Percentage of supplied assets being borrowed"
               dataKey="utilization"
               color="rgba(99, 102, 241, 0.95)"
+              className={CARD_STYLES}
             />
             <MarketChart
               data={history}
@@ -190,12 +192,13 @@ export default function MarketPage() {
               description="Annual Percentage Yield"
               dataKey="apy"
               color="rgba(245, 158, 11, 0.95)"
+              className={CARD_STYLES}
             />
           </div>
 
           {/* Performance Section */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader>
                 <CardTitle className="text-gray-200">7D APY</CardTitle>
               </CardHeader>
@@ -206,7 +209,7 @@ export default function MarketPage() {
               </CardContent>
             </Card>
 
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader>
                 <CardTitle className="text-gray-200">30D APY</CardTitle>
               </CardHeader>
@@ -217,7 +220,7 @@ export default function MarketPage() {
               </CardContent>
             </Card>
 
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader>
                 <CardTitle className="text-gray-200">90D APY</CardTitle>
               </CardHeader>
@@ -233,7 +236,7 @@ export default function MarketPage() {
           <div className="space-y-6">
             <h2 className="text-xl font-bold text-gray-200">Risk</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <Card className={CARD_STYLES}>
                 <CardHeader>
                   <CardTitle className="text-gray-200 flex items-center gap-2">
                     Risk Rating by Credora ®
@@ -244,7 +247,7 @@ export default function MarketPage() {
                 </CardContent>
               </Card>
 
-              <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <Card className={CARD_STYLES}>
                 <CardHeader>
                   <CardTitle className="text-gray-200">Curator TVL</CardTitle>
                 </CardHeader>
@@ -253,7 +256,7 @@ export default function MarketPage() {
                 </CardContent>
               </Card>
 
-              <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <Card className={CARD_STYLES}>
                 <CardHeader>
                   <CardTitle className="text-gray-200">Vault Deployment Date</CardTitle>
                 </CardHeader>
@@ -262,7 +265,7 @@ export default function MarketPage() {
                 </CardContent>
               </Card>
 
-              <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <Card className={CARD_STYLES}>
                 <CardHeader>
                   <CardTitle className="text-gray-200">Owner</CardTitle>
                 </CardHeader>
@@ -271,7 +274,7 @@ export default function MarketPage() {
                 </CardContent>
               </Card>
 
-              <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <Card className={CARD_STYLES}>
                 <CardHeader>
                   <CardTitle className="text-gray-200">Curator Address</CardTitle>
                 </CardHeader>
@@ -280,7 +283,7 @@ export default function MarketPage() {
                 </CardContent>
               </Card>
 
-              <Card className="bg-gray-700/60 border-none rounded-3xl">
+              <Card className={CARD_STYLES}>
                 <CardHeader>
                   <CardTitle className="text-gray-200">Timelock / Guardian</CardTitle>
                 </CardHeader>
@@ -296,7 +299,7 @@ export default function MarketPage() {
             <h2 className="text-xl font-bold text-gray-200 flex items-center gap-2">
               Disclosures <InfoIcon className="h-4 w-4 text-gray-400" />
             </h2>
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardContent className="pt-6">
                 <p className="text-gray-400">Curator has not submitted a Disclosure.</p>
               </CardContent>
@@ -308,7 +311,7 @@ export default function MarketPage() {
         <div className="col-span-1 lg:sticky top-6 self-start max-h-[calc(100vh-4rem)] overflow-y-auto">
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             {/* Supply Card */}
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader className="pb-2">
                 <CardTitle className="text-gray-200 text-base font-medium">
                   Supply Collateral {market.collateralSymbol}
@@ -340,7 +343,7 @@ export default function MarketPage() {
             </Card>
 
             {/* Borrow Card */}
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardHeader className="pb-2">
                 <CardTitle className="text-gray-200 text-base font-medium">
                   Borrow {market.loanSymbol}
@@ -372,7 +375,7 @@ export default function MarketPage() {
             </Card>
 
             {/* Position Card */}
-            <Card className="bg-gray-700/60 border-none rounded-3xl">
+            <Card className={CARD_STYLES}>
               <CardContent className="pt-4 space-y-4">
                 <div>
                   <div className="text-sm text-gray-400">My collateral position ({market.collateralSymbol})</div>

--- a/frontend/app/(app)/borrow/components/market-chart.tsx
+++ b/frontend/app/(app)/borrow/components/market-chart.tsx
@@ -20,7 +20,7 @@ export function MarketChart({
   color = "rgb(99, 102, 241)"
 }: MarketChartProps) {
   return (
-    <Card className="bg-gray-700/60 border-none">
+    <Card className="bg-gray-700/60 border-none rounded-3xl">
       <CardHeader className="pb-4">
         <CardTitle className="text-gray-200">{title}</CardTitle>
         <CardDescription className="text-gray-400">{description}</CardDescription>

--- a/frontend/app/(app)/borrow/components/market-chart.tsx
+++ b/frontend/app/(app)/borrow/components/market-chart.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
 import { MarketHistory } from "../mock-history"
 
@@ -10,6 +11,7 @@ interface MarketChartProps {
   description: string
   dataKey: string
   color?: string
+  className?: string
 }
 
 export function MarketChart({
@@ -17,10 +19,11 @@ export function MarketChart({
   title,
   description,
   dataKey,
-  color = "rgb(99, 102, 241)"
+  color = "rgb(99, 102, 241)",
+  className
 }: MarketChartProps) {
   return (
-    <Card className="bg-gray-700/60 border-none rounded-3xl">
+    <Card className={cn("bg-gray-700/60 border-none rounded-3xl", className)}>
       <CardHeader className="pb-4">
         <CardTitle className="text-gray-200">{title}</CardTitle>
         <CardDescription className="text-gray-400">{description}</CardDescription>

--- a/frontend/app/(app)/borrow/layout.tsx
+++ b/frontend/app/(app)/borrow/layout.tsx
@@ -10,8 +10,8 @@ export default function BorrowLayout({
 }) {
   return (
     <div className="h-full w-full px-6">
-      <Card className="w-full h-[91vh] bg-gray-800/80 border-none overflow-y-auto hide-scrollbar ">
-        <CardContent className="p-6 justify-center">
+      <Card className="w-full h-[91vh] bg-gray-800/80 border-none overflow-y-auto hide-scrollbar rounded-3xl">
+        <CardContent className="px-6 justify-center">
           {children}
         </CardContent>
       </Card>

--- a/frontend/app/(app)/borrow/page.tsx
+++ b/frontend/app/(app)/borrow/page.tsx
@@ -19,8 +19,8 @@ export default function BorrowPage() {
   }
 
   return (
-    <div className="py-6">
-      <Card className="mb-6 bg-customGray-800/60 backdrop-blur-sm">
+    <div className="">
+      <Card className="mb-6 bg-customGray-800/60 backdrop-blur-sm rounded-3xl">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-muted-foreground">My Loan</CardTitle>
           <div className="text-4xl font-bold text-gray-200">$0.00</div>

--- a/frontend/components/ui/data-table.tsx
+++ b/frontend/components/ui/data-table.tsx
@@ -67,15 +67,15 @@ export function DataTable<TData, TValue>({
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id} className="bg-gradient-to-b from-customGray-900/80 to-gray-900/70 border-none rounded-lg">
+            <TableRow key={headerGroup.id} className="bg-gray-700/60 border-none rounded-3xl">
               {headerGroup.headers.map((header, index) => {
                 return (
                   <TableHead 
                     key={header.id} 
                     className={cn(
                       "text-gray-200 h-12",
-                      index === 0 && "rounded-l-lg",
-                      index === headerGroup.headers.length - 1 && "rounded-r-lg"
+                      index === 0 && "rounded-l-3xl",
+                      index === headerGroup.headers.length - 1 && "rounded-r-3xl"
                     )}
                   >
                     {header.isPlaceholder
@@ -96,7 +96,7 @@ export function DataTable<TData, TValue>({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && "selected"}
-                className="bg-customGray-950/60 hover:bg-customGray-900/60 my-1 border-none transition-colors rounded-lg"
+                className="bg-gray-700/40 hover:bg-gray-600/60 my-1 border-none transition-colors rounded-3xl cursor-pointer"
                 onClick={() => onRowClick?.(row.id)}
               >
                 {row.getVisibleCells().map((cell, index) => (
@@ -104,8 +104,8 @@ export function DataTable<TData, TValue>({
                     key={cell.id} 
                     className={cn(
                       "text-gray-200",
-                      index === 0 && "rounded-l-lg",
-                      index === row.getVisibleCells().length - 1 && "rounded-r-lg"
+                      index === 0 && "rounded-l-3xl",
+                      index === row.getVisibleCells().length - 1 && "rounded-r-3xl"
                     )}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -114,8 +114,8 @@ export function DataTable<TData, TValue>({
               </TableRow>
             ))
           ) : (
-            <TableRow className="rounded-lg">
-              <TableCell colSpan={columns.length} className="h-24 text-center text-gray-400 rounded-lg">
+            <TableRow className="rounded-3xl">
+              <TableCell colSpan={columns.length} className="h-24 text-center text-gray-400 rounded-3xl">
                 No results.
               </TableCell>
             </TableRow>
@@ -129,7 +129,7 @@ export function DataTable<TData, TValue>({
             size="sm"
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
-            className="text-gray-200 hover:text-gray-100 hover:bg-customGray-900/60 rounded-lg"
+            className="text-gray-200 hover:text-gray-100 hover:bg-gray-600/60 rounded-3xl"
           >
             Previous
           </Button>
@@ -142,7 +142,7 @@ export function DataTable<TData, TValue>({
             size="sm"
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
-            className="text-gray-200 hover:text-gray-100 hover:bg-customGray-900/60 rounded-lg"
+            className="text-gray-200 hover:text-gray-100 hover:bg-gray-600/60 rounded-3xl"
           >
             Next
           </Button>

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -8,9 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-transparent dark:bg-transparent flex h-8 w-full min-w-0 rounded-md border-none bg-transparent text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,8 @@
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook": "^0.0.1",
+        "react-hook-form": "^7.55.0",
         "tailwind-merge": "^3.0.2",
         "tw-animate-css": "^1.2.4"
       },
@@ -7250,6 +7252,28 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/react-hook/-/react-hook-0.0.1.tgz",
+      "integrity": "sha512-2/Guf88/dGyFgUT7QDtBJ1l7V5yqTcAHlNRIZNTu2xg0KkDjaiYZp79ah49NDaLMI/J7voWcKLU8wMONG4A/1g==",
+      "license": "ISC"
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.55.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
+      "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,8 @@
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook": "^0.0.1",
+    "react-hook-form": "^7.55.0",
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.4"
   },


### PR DESCRIPTION
- adds input cards for inputting collaterall/borrow etc (they are sticki which means they follow the scrollbar)
- adds more rounded edges on the cards
- regulates coloring in the data table
- regulates padding throughout the app so it looks better
- current state of specific market page:
![image](https://github.com/user-attachments/assets/f96a010c-4f46-439d-aac0-791c8d4bb39a)
